### PR TITLE
Remove runit lock from god

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Installs and configures god and provides a define for monitoring"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "1.0.2"
+version           "1.0.3"
 
 recipe "god", "Installs god and starts it as a runit service"
 
@@ -12,4 +12,4 @@ recipe "god", "Installs god and starts it as a runit service"
   supports os
 end
 
-depends "runit", "<= 0.16.2"
+depends "runit"


### PR DESCRIPTION
In order to fix dependency issues with the older version of runit, this
commit removes the dependency lock and bumps the version.
